### PR TITLE
infinite recursion

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -68,7 +68,7 @@ has_node_modules() {
 }
 
 venv_cd() {
-	cd "$@" && has_virtualenv && has_node_modules
+	\cd "$@" && has_virtualenv && has_node_modules
 }
 alias cd="venv_cd"
 


### PR DESCRIPTION
The aliasing of `cd` with a function that calls `cd` seems to cause infinite recursion in bash 4.3.30 and previous under Mac OSx.
Calling the original cd as \cd forces to use the default not-aliased command and seems to fix the issue.
